### PR TITLE
OT-ContainerizeSessionHandler | Put session handler into a docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM adoptopenjdk/openjdk11
+COPY /target/SessionHandlerService-0.0.1-SNAPSHOT.jar SessionHandlerService-0.0.1-SNAPSHOT.jar
+EXPOSE 9000
+ENTRYPOINT ["java","-jar","SessionHandlerService-0.0.1-SNAPSHOT.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3'
+services:
+  session-handler:
+    build:
+      context: ./
+      dockerfile: Dockerfile
+    image: session-handler
+    ports:
+      - 9000:9000
+
+networks:
+  default:
+    external:
+      name: offtop-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: ./
       dockerfile: Dockerfile
-    image: session-handler-v1.01
+    image: session-handler:1.0
     ports:
       - 9000:9000
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: ./
       dockerfile: Dockerfile
-    image: session-handler
+    image: session-handler-v1.01
     ports:
       - 9000:9000
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,20 +2,23 @@ spring.devtools.restart.enabled=true
 spring.devtools.remote.secret=offtop
 server.port=9000
 
-
 #Kafka Consumer Settings
-spring.kafka.consumer.bootstrap-servers=desktop_kakfa_1:9092
+##UNCOMMENT THE LINE BELOW IF YOU WANT TO USE DOCKER KAFKA
+spring.kafka.consumer.bootstrap-servers=kafka:9092
+##UNCOMMENT THE LINE BELOW IF YOU WANT TO USE LOCAL KAFKA
+#spring.kafka.consumer.bootstrap-servers=localhost:9092
 spring.kafka.consumer.auto-offset-reset=earliest
 spring.kafka.consumer.group-id=group_id
 spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
 spring.kafka.consumer.value-deserializer=org.apache.kafka.common.serialization.StringDeserializer
 
 #Kafka Producer Settings
-spring.kafka.producer.bootstrap-servers=desktop_kafka_1:9092
+##UNCOMMENT THE LINE BELOW IF YOU WANT TO USE DOCKER KAFKA
+spring.kafka.producer.bootstrap-servers=kafka:9092
+##UNCOMMENT THE LINE BELOW IF YOU WANT TO USE LOCAL KAFKA
+#spring.kafka.producer.bootstrap-servers=localhost:9092
 spring.kafka.producer.key-serializer= org.apache.kafka.common.serialization.StringSerializer
 spring.kafka.producer.value-serializer=org.apache.kafka.common.serialization.StringSerializer
 
-
 #set topics to false if topic is not created
 spring.kafka.listener.missing-topics-fatal=false
-

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,14 +4,14 @@ server.port=9000
 
 
 #Kafka Consumer Settings
-spring.kafka.consumer.bootstrap-servers=localhost:9092
+spring.kafka.consumer.bootstrap-servers=desktop_kakfa_1:9092
 spring.kafka.consumer.auto-offset-reset=earliest
 spring.kafka.consumer.group-id=group_id
 spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
 spring.kafka.consumer.value-deserializer=org.apache.kafka.common.serialization.StringDeserializer
 
 #Kafka Producer Settings
-spring.kafka.producer.bootstrap-servers=localhost:9092
+spring.kafka.producer.bootstrap-servers=desktop_kafka_1:9092
 spring.kafka.producer.key-serializer= org.apache.kafka.common.serialization.StringSerializer
 spring.kafka.producer.value-serializer=org.apache.kafka.common.serialization.StringSerializer
 


### PR DESCRIPTION
**What I Did:**
- Used Docker to put Session Handler into a container
- Connected the containerized Session Handler with a containerized Kafka 

**How to Test:**
- Make sure that you are able to connect to the containerized Kafka/Zookeeper server. The instructions can be found here: https://docs.google.com/document/d/1r5LvXN-08kG8zBy7SFDBJ_80pMHdjJU8RrkNpSqQzAs/edit: 
- Follow the instructions here to set up the containerized Session Handler: https://docs.google.com/document/d/1gDpvS-ktm1ZisaHLzl053rj8j4_YAB7CyiZloR-vQYc/edit
- If you are able to get these two steps working, then Session Handler is containerized.
- Revert back to using localhost for Kafka and comment out lines 7 and 17, and uncomment lines 9 and 19 of application.properties
![image](https://user-images.githubusercontent.com/36316432/89082284-612f1800-d342-11ea-8bda-79260ab49771.png)
- Run Session Handler with `mvn spring-boot:run` and test with Flutter and Python consumer and producer to make sure it's still working as intended. 

 
